### PR TITLE
Invalid path parameter causes URISyntaxException

### DIFF
--- a/src/main/java/com/growthbeat/model/Account.java
+++ b/src/main/java/com/growthbeat/model/Account.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 public class Account extends Model {
 
@@ -42,7 +43,7 @@ public class Account extends Model {
 	}
 
 	public static Account findById(String id, Context context) {
-		return get(context, String.format("1/accounts/%s", id), new HashMap<String, Object>(), Account.class);
+		return get(context, String.format("1/accounts/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Account.class);
 	}
 
 	public static List<Account> findAccountsById(String id, Context context) {
@@ -60,10 +61,10 @@ public class Account extends Model {
 		return post(context, "1/accounts", params, Account.class);
 	}
 
-	public static Account update(String accountId, String name, Context context) {
+	public static Account update(String id, String name, Context context) {
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("name", name);
-		return put(context, "1/accounts/" + accountId, params, Account.class);
+		return put(context, String.format("1/accounts/%s", StringUtils.urlEncode(id)), params, Account.class);
 	}
 
 }

--- a/src/main/java/com/growthbeat/model/Application.java
+++ b/src/main/java/com/growthbeat/model/Application.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 public class Application extends Model {
 
@@ -42,7 +43,7 @@ public class Application extends Model {
 	}
 
 	public static Application findById(String id, Context context) {
-		return get(context, String.format("1/applications/%s", id), new HashMap<String, Object>(), Application.class);
+		return get(context, String.format("1/applications/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Application.class);
 	}
 
 	public static List<Application> findByAccountId(String accounId, Context context) {
@@ -63,7 +64,6 @@ public class Application extends Model {
 	public static Application update(String id, String name, Context context) {
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("name", name);
-		return put(context, String.format("1/applications/%s", id), params, Application.class);
+		return put(context, String.format("1/applications/%s", StringUtils.urlEncode(id)), params, Application.class);
 	}
-
 }

--- a/src/main/java/com/growthbeat/model/Client.java
+++ b/src/main/java/com/growthbeat/model/Client.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 public class Client extends Model {
 
@@ -42,7 +43,7 @@ public class Client extends Model {
 	}
 
 	public static Client findById(String id, Context context) {
-		return get(context, String.format("1/clients/%s", id), new HashMap<String, Object>(), Client.class);
+		return get(context, String.format("1/clients/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Client.class);
 	}
 
 	public static List<Client> findByApplicationId(String applicationId, String id, Order order, Integer limit, Context context) {

--- a/src/main/java/com/growthbeat/model/Credential.java
+++ b/src/main/java/com/growthbeat/model/Credential.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 public class Credential extends Model {
 
@@ -42,7 +43,7 @@ public class Credential extends Model {
 	}
 
 	public static Credential findById(String id, Context context) {
-		return get(context, String.format("1/credentials/%s", id), new HashMap<String, Object>(), Credential.class);
+		return get(context, String.format("1/credentials/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Credential.class);
 	}
 
 	public static List<Credential> findByAccountId(String accountId, Context context) {

--- a/src/main/java/com/growthbeat/model/Intent.java
+++ b/src/main/java/com/growthbeat/model/Intent.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 @JsonDeserialize(using = JsonIntentDeserializer.class)
 public abstract class Intent extends Model {
@@ -87,7 +88,7 @@ public abstract class Intent extends Model {
 	}
 
 	public static Intent findById(String id, Context context) {
-		return get(context, String.format("1/intents/%s", id), new HashMap<String, Object>(), Intent.class);
+		return get(context, String.format("1/intents/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Intent.class);
 	}
 
 	public static List<Intent> findByApplicationId(String applicationId, Order order, Integer page, Integer limit, Context context) {
@@ -141,7 +142,7 @@ public abstract class Intent extends Model {
 		params.put("type", IntentType.custom);
 		for (Map.Entry<String, String> entry : extra.entrySet())
 			params.put(String.format("extra[%s]", entry.getKey()), entry.getValue());
-		return put(context, String.format("1/intents/%s", id), params, Intent.class);
+		return put(context, String.format("1/intents/%s", StringUtils.urlEncode(id)), params, Intent.class);
 	}
 
 	public static Intent updateNoopIntent(String id, String name, String description, Context context) {
@@ -149,7 +150,7 @@ public abstract class Intent extends Model {
 		params.put("name", name);
 		params.put("description", description);
 		params.put("type", IntentType.noop);
-		return put(context, String.format("1/intents/%s", id), params, Intent.class);
+		return put(context, String.format("1/intents/%s", StringUtils.urlEncode(id)), params, Intent.class);
 	}
 
 	public static Intent updateUrlIntent(String id, String name, String description, String url, Context context) {
@@ -158,11 +159,11 @@ public abstract class Intent extends Model {
 		params.put("description", description);
 		params.put("type", IntentType.url);
 		params.put("url", url);
-		return put(context, String.format("1/intents/%s", id), params, Intent.class);
+		return put(context, String.format("1/intents/%s", StringUtils.urlEncode(id)), params, Intent.class);
 	}
 
 	public static void delete(String id, Context context) {
-		delete(context, String.format("1/intents/%s", id), new HashMap<String, Object>(), Void.class);
+		delete(context, String.format("1/intents/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Void.class);
 	}
 
 }

--- a/src/main/java/com/growthbeat/model/Session.java
+++ b/src/main/java/com/growthbeat/model/Session.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.growthbeat.Context;
 import com.growthbeat.constants.Constants;
+import com.growthbeat.utils.StringUtils;
 
 public class Session extends Model {
 
@@ -48,7 +49,7 @@ public class Session extends Model {
 	}
 
 	public static Session findById(String id, Context context) {
-		return get(context, String.format("1/sessions/%s", id), new HashMap<String, Object>(), Session.class);
+		return get(context, String.format("1/sessions/%s", StringUtils.urlEncode(id)), new HashMap<String, Object>(), Session.class);
 	}
 
 }

--- a/src/main/java/com/growthbeat/utils/StringUtils.java
+++ b/src/main/java/com/growthbeat/utils/StringUtils.java
@@ -1,0 +1,26 @@
+package com.growthbeat.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+public class StringUtils extends org.apache.commons.lang3.StringUtils {
+
+	public static String urlEncode(String string) {
+		try {
+			return URLEncoder.encode(string, Charset.defaultCharset().toString());
+		} catch (UnsupportedEncodingException e) {
+			return null;
+		}
+	}
+
+	public static String urlDecode(String string) {
+		try {
+			return URLDecoder.decode(string, Charset.defaultCharset().toString());
+		} catch (UnsupportedEncodingException e) {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
Invalid path parameter causes URISyntaxException

```java
new Growthbeat("xxx").findApplicationByApplicationId("{}");
```

The path parameter must be encoded before sending request.

```java
java.lang.IllegalArgumentException: Illegal character in path at index 42: https://api.growthbeat.com/1/applications/{}?credentialId=xxxx
	at java.net.URI.create(URI.java:852)
	at org.apache.http.client.methods.HttpGet.<init>(HttpGet.java:69)
	at com.growthbeat.http.GrowthbeatHttpClient.get(GrowthbeatHttpClient.java:65)
	at com.growthbeat.model.Model.get(Model.java:45)
	at com.growthbeat.model.Model.get(Model.java:12)
	at com.growthbeat.model.Application.findById(Application.java:45)
	at com.growthbeat.Growthbeat.findApplicationByApplicationId(Growthbeat.java:61)
	at in.katty.testsite.App.main(App.java:27)
	... 6 more
Caused by: java.net.URISyntaxException: Illegal character in path at index 42: https://api.growthbeat.com/1/applications/{}?credentialId=xxxx
	at java.net.URI$Parser.fail(URI.java:2848)
	at java.net.URI$Parser.checkChars(URI.java:3021)
	at java.net.URI$Parser.parseHierarchical(URI.java:3105)
	at java.net.URI$Parser.parse(URI.java:3053)
	at java.net.URI.<init>(URI.java:588)
	at java.net.URI.create(URI.java:850)
	... 13 more
```